### PR TITLE
Modifica forma de verificação para hidratação de array por propriedade

### DIFF
--- a/src/Traits/Serializable.php
+++ b/src/Traits/Serializable.php
@@ -2,6 +2,7 @@
 
 namespace Jetimob\Http\Traits;
 
+use Illuminate\Support\Str;
 use Jetimob\Http\Exceptions\RuntimeException;
 
 trait Serializable
@@ -39,8 +40,9 @@ trait Serializable
     {
         // if there is a method named {$propertyName}ArrayItemType in this class, it should return the type (class that
         // uses the Jetimob\Http\Traits\Serializable trait) of the items of the given array
-        if (method_exists($this, "{$propertyName}ItemType")
-            && class_exists($class = $this->{"{$propertyName}ItemType"}())
+        $propertyNameCamelCased = Str::camel($propertyName);
+        if (method_exists($this, "{$propertyNameCamelCased}ItemType")
+            && class_exists($class = $this->{"{$propertyNameCamelCased}ItemType"}())
             && method_exists($class, 'deserializeArray')
         ) {
             $this->{$propertyName} = $class::deserializeArray($array);


### PR DESCRIPTION
A alteração a seguir foi realizada com a finalidade de seguir a [PSR-1](https://www.php-fig.org/psr/psr-1/) no que diz respeito na declaração de métodos (último item).

A forma atual de criar o método para hidratar as propriedades do tipo array segue o padrão de escrita literal da propriedade em questão, quando a propriedade é snake-case acontece de ser obrigado a utilizar snake-case e camel-case.

Exemplo:
```PHP
    class Example extends Response {
        protected array $snake_case;
        
        public function snake_caseTypeItem(): string 
        {
             return SomeClassType::class;
        }
    }
```

Com isso, não segue o recomendado pela PSR e, além disso, se faz necessário utilizar snake-case e camel-case na declaração do mesmo método;

Com a alteração proposta:

Exemplo:
```PHP
    class Example extends Response {
        protected array $snake_case;
        
        public function snakCaseTypeItem(): string 
        {
             return SomeClassType::class;
        }
    }
```
