### PR TITLE
docs: Adiciona tipo genérico do retorno da request baseado na classe recebida como parâmetro

### DIFF
--- a/src/AbstractApi.php
+++ b/src/AbstractApi.php
@@ -104,7 +104,12 @@ abstract class AbstractApi
      * given $responseClass.
      * This response class MUST inherit from \Jetimob\Http\Response.
      *
-     * @return Response
+     * @template  T
+     * @param string $method
+     * @param string $path
+     * @param class-string<T> $responseClass
+     *
+     * @return T
      * @throws \Throwable
      * @throws \JsonException
      */
@@ -143,11 +148,12 @@ abstract class AbstractApi
     }
 
     /**
+     * @template T
      * @param string $path
-     * @param string $responseClass
+     * @param class-string<T> $responseClass
      * @param array  $options
      *
-     * @return Response
+     * @return T
      * @throws \JsonException
      * @throws \Throwable
      * @see AbstractApi::mappedRequest()
@@ -161,11 +167,12 @@ abstract class AbstractApi
     }
 
     /**
+     * @template T
      * @param string $path
-     * @param string $responseClass
+     * @param class-string<T> $responseClass
      * @param array  $options Guzzle Options
      *
-     * @return Response
+     * @return T
      * @throws \JsonException
      * @throws \Throwable
      * @see AbstractApi::mappedRequest()
@@ -179,11 +186,12 @@ abstract class AbstractApi
     }
 
     /**
+     * @template T
      * @param string $path
-     * @param string $responseClass
+     * @param class-string<T> $responseClass
      * @param array  $options Guzzle Options
      *
-     * @return Response
+     * @return T
      * @throws \JsonException
      * @throws \Throwable
      * @see AbstractApi::mappedRequest()
@@ -197,11 +205,12 @@ abstract class AbstractApi
     }
 
     /**
+     * @template T
      * @param string $path
-     * @param string $responseClass
+     * @param class-string<T> $responseClass
      * @param array  $options Guzzle Options
      *
-     * @return Response
+     * @return T
      * @throws \JsonException
      * @throws \Throwable
      * @see AbstractApi::mappedRequest()


### PR DESCRIPTION
Tem como fazer uma ["generic"](https://phpstan.org/blog/generics-in-php-using-phpdocs) usando phpdocs.

Dessa forma com a generic a IntelliSense entende que o retorno do método vai ser uma instância da classe passada como parâmetro.